### PR TITLE
Add simple SQLite-backed web-page watcher CLI (monitor_app.py) with seeds and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+watcher.db

--- a/README.md
+++ b/README.md
@@ -1,49 +1,46 @@
 # Hiroasa
 
-Webページ更新監視の最小アプリです（SQLite + 標準ライブラリのみ）。
+ブラウザで使える **Webページ更新監視サイト** です。  
+URLを画面から登録し、監視実行と変更履歴の確認ができます。
 
-## セットアップ
+## 起動方法（3ステップ）
+
+```bash
+python3 web_app.py --host 127.0.0.1 --port 8000
+```
+
+ブラウザで以下を開きます。
+
+- <http://127.0.0.1:8000>
+
+## 画面でできること
+
+- 初期URL（45件）を投入
+- 監視対象URLの追加/更新
+- 件数指定で監視実行
+- 最新イベント履歴の確認
+
+## CLIを使う場合（任意）
+
+Web画面を使わず、コマンドだけで操作することもできます。
 
 ```bash
 python3 monitor_app.py init-db
 python3 monitor_app.py seed-defaults
-```
-
-## 使い方
-
-### 監視対象一覧
-```bash
 python3 monitor_app.py list-monitors
-```
-
-### 一回だけ監視実行
-```bash
-python3 monitor_app.py run-once
-```
-
-テスト用途で件数を絞る場合:
-```bash
 python3 monitor_app.py run-once --limit 5
 ```
-
-### 常駐実行（ポーリング）
-```bash
-python3 monitor_app.py run-daemon --poll-sec 300
-```
-
-## 収集データ
-
-- `monitors`: 監視URL設定
-- `monitor_state`: 最新状態（fingerprint / etag / last-modified / エラー）
-- `change_events`: 変更・取得失敗イベント履歴
 
 ## 監視方式
 
 - `HTML_HASH`: HTMLを正規化してハッシュ比較
-- `HTTP_META_THEN_HASH`: HEADでメタ情報確認 + GET内容のハッシュ比較
+- `HTTP_META_THEN_HASH`: HEADメタ情報 + GET内容のハッシュ比較
 - `HTTP_META_ONLY`: ETag/Last-Modifiedのみで疎監視
 
-## 備考
+## 保存されるデータ
 
-- 初回実行はベースライン作成となり、通常は変更通知を出しません。
-- 政府サイト側の構成変更により、一時的な誤検知や取得失敗が発生することがあります。
+- `monitors`: 監視設定
+- `monitor_state`: 最新状態
+- `change_events`: 変更/取得失敗イベント
+
+SQLiteファイルは `watcher.db` です。

--- a/README.md
+++ b/README.md
@@ -1,46 +1,41 @@
 # Hiroasa
 
-ブラウザで使える **Webページ更新監視サイト** です。  
-URLを画面から登録し、監視実行と変更履歴の確認ができます。
+だれでも使えるように、**起動すると自動でブラウザが開く** 監視Webサイトにしました。
 
-## 起動方法（3ステップ）
+## いちばん簡単な使い方
 
+### Windows
+`start_web.bat` をダブルクリック。
+
+### Mac / Linux
 ```bash
-python3 web_app.py --host 127.0.0.1 --port 8000
+./start_web.sh
 ```
 
-ブラウザで以下を開きます。
+または共通で:
+```bash
+python3 run_web.py
+```
 
+起動するとブラウザで以下が開きます。
 - <http://127.0.0.1:8000>
 
-## 画面でできること
+## 使い方（画面）
 
-- 初期URL（45件）を投入
-- 監視対象URLの追加/更新
+- 初回起動時は45件の監視URLを自動投入
+- URLの追加/更新
 - 件数指定で監視実行
 - 最新イベント履歴の確認
 
-## CLIを使う場合（任意）
+## 停止
 
-Web画面を使わず、コマンドだけで操作することもできます。
+ターミナルで `Ctrl + C`。
 
+## 補足（上級者向け）
+
+自動でブラウザを開きたくない場合:
 ```bash
-python3 monitor_app.py init-db
-python3 monitor_app.py seed-defaults
-python3 monitor_app.py list-monitors
-python3 monitor_app.py run-once --limit 5
+python3 web_app.py --no-open-browser
 ```
-
-## 監視方式
-
-- `HTML_HASH`: HTMLを正規化してハッシュ比較
-- `HTTP_META_THEN_HASH`: HEADメタ情報 + GET内容のハッシュ比較
-- `HTTP_META_ONLY`: ETag/Last-Modifiedのみで疎監視
-
-## 保存されるデータ
-
-- `monitors`: 監視設定
-- `monitor_state`: 最新状態
-- `change_events`: 変更/取得失敗イベント
 
 SQLiteファイルは `watcher.db` です。

--- a/README.md
+++ b/README.md
@@ -1,1 +1,49 @@
 # Hiroasa
+
+Webページ更新監視の最小アプリです（SQLite + 標準ライブラリのみ）。
+
+## セットアップ
+
+```bash
+python3 monitor_app.py init-db
+python3 monitor_app.py seed-defaults
+```
+
+## 使い方
+
+### 監視対象一覧
+```bash
+python3 monitor_app.py list-monitors
+```
+
+### 一回だけ監視実行
+```bash
+python3 monitor_app.py run-once
+```
+
+テスト用途で件数を絞る場合:
+```bash
+python3 monitor_app.py run-once --limit 5
+```
+
+### 常駐実行（ポーリング）
+```bash
+python3 monitor_app.py run-daemon --poll-sec 300
+```
+
+## 収集データ
+
+- `monitors`: 監視URL設定
+- `monitor_state`: 最新状態（fingerprint / etag / last-modified / エラー）
+- `change_events`: 変更・取得失敗イベント履歴
+
+## 監視方式
+
+- `HTML_HASH`: HTMLを正規化してハッシュ比較
+- `HTTP_META_THEN_HASH`: HEADでメタ情報確認 + GET内容のハッシュ比較
+- `HTTP_META_ONLY`: ETag/Last-Modifiedのみで疎監視
+
+## 備考
+
+- 初回実行はベースライン作成となり、通常は変更通知を出しません。
+- 政府サイト側の構成変更により、一時的な誤検知や取得失敗が発生することがあります。

--- a/monitor_app.py
+++ b/monitor_app.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""Simple web-page watch app for MLIT related URLs.
+
+Usage examples:
+  python monitor_app.py init-db
+  python monitor_app.py seed-defaults
+  python monitor_app.py list-monitors
+  python monitor_app.py run-once --limit 5
+  python monitor_app.py run-daemon --poll-sec 300
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import json
+import re
+import sqlite3
+import time
+import urllib.error
+import urllib.request
+from dataclasses import dataclass
+from typing import Iterable, Optional
+
+DB_PATH = "watcher.db"
+USER_AGENT = "HiroasaWatcher/1.0 (+https://example.local)"
+TIMEOUT_SEC = 30
+
+
+@dataclass(frozen=True)
+class MonitorSeed:
+    display_name: str
+    url: str
+    watch_type: str
+    document_type: str
+    category: str
+    bureau_code: str
+    interval_min: int
+    note: str
+
+
+SEEDS: list[MonitorSeed] = [
+    MonitorSeed("技術調査関係報道発表資料（最新）", "https://www.mlit.go.jp/report/press/gijutsu_news.html", "HTML_HASH", "参考資料", "インフラDX", "PRESS", 30, "技術調査系の最新報道発表を一次検知。RSS補完推奨。"),
+    MonitorSeed("技術調査：新着情報一覧", "https://www.mlit.go.jp/tec/news.html", "HTML_HASH", "参考資料", "インフラDX", "TEC", 30, "技術調査分野の新着一覧。RSS併用推奨。"),
+    MonitorSeed("建設施工・建設機械：新着情報一覧", "https://www.mlit.go.jp/tec/constplan/news.html", "HTML_HASH", "参考資料", "ICT施工", "CONSTPLAN", 30, "施工系の新着集約。RSS併用推奨。"),
+    MonitorSeed("BIM/CIM関連（技術調査）", "https://www.mlit.go.jp/tec/tec_tk_000037.html", "HTML_HASH", "参考資料", "BIM/CIM", "TEC", 60, "BIM/CIM最重要ハブ。"),
+    MonitorSeed("BIM/CIM関連基準要領等（令和7年3月）", "https://www.mlit.go.jp/tec/tec_fr_000158.html", "HTML_HASH", "参考資料", "BIM/CIM", "TEC", 60, "年度版基準要領等のハブ。"),
+    MonitorSeed("BIM/CIMポータル：基準・要領等（最新版）", "https://www.nilim.go.jp/lab/qbg/bimcim/standard.html", "HTML_HASH", "参考資料", "BIM/CIM", "NILIM", 60, "公式ポータル。"),
+    MonitorSeed("BIM/CIMポータル：活用事例（検索/一覧）", "https://www.nilim.go.jp/lab/qbg/bimcim/usecase/index.html", "HTML_HASH", "参考資料", "BIM/CIM", "NILIM", 120, "事例更新監視。"),
+    MonitorSeed("土木工事数量算出要領（令和7年度）", "https://www.nilim.go.jp/lab/pbg/theme/theme2/sr/yoryo0704.htm", "HTTP_META_THEN_HASH", "要領", "BIM/CIM", "NILIM", 360, "年度更新あり。"),
+    MonitorSeed("公共測量：マニュアル・要領等のダウンロード（GSI）", "https://www.gsi.go.jp/gijyutukanri/gijyutukanri41021.html", "HTML_HASH", "マニュアル", "測量・3次元", "GSI", 120, "改正情報の集約。"),
+    MonitorSeed("3次元数値地形図データ作成マニュアル（説明ページ）", "https://www.gsi.go.jp/gijyutukanri/gijyutukanri41029.html", "HTML_HASH", "マニュアル", "測量・3次元", "GSI", 120, "説明ページ更新監視。"),
+    MonitorSeed("3次元数値地形図データ作成マニュアル（PDF）", "https://www.gsi.go.jp/common/000259826.pdf", "HTTP_META_THEN_HASH", "マニュアル", "測量・3次元", "GSI", 720, "PDF直リンク。ETag/Last-Modified優先。"),
+    MonitorSeed("電子納品サイト（トップ）", "https://www.cals-ed.go.jp/", "HTML_HASH", "参考資料", "電子納品", "CALED", 120, "改定/停止告知監視。"),
+    MonitorSeed("電子納品：要領・基準一覧（cri_point）", "https://www.cals-ed.go.jp/cri_point/", "HTML_HASH", "基準", "電子納品", "CALED", 120, "最新版リンク集。"),
+    MonitorSeed("電子納品：改定のお知らせ（2024/03/29）", "https://www.cals-ed.go.jp/youryou-rev-20240329/", "HTML_HASH", "事務連絡", "電子納品", "CALED", 720, "改定告知ページ。"),
+    MonitorSeed("電子納品：DTD・XML記入例", "https://www.cals-ed.go.jp/cri_dtdxml/", "HTML_HASH", "参考資料", "電子納品", "CALED", 120, "DTD/ZIP更新監視。"),
+    MonitorSeed("i-Construction（新着一覧が長いトップ）", "https://www.mlit.go.jp/tec/i-construction/index.html", "HTML_HASH", "参考資料", "i-Construction", "TEC", 60, "時系列更新多め。"),
+    MonitorSeed("i-Construction・インフラDX推進コンソーシアム（概要）", "https://www.mlit.go.jp/tec/i-construction/i-con_consortium/index.html", "HTML_HASH", "参考資料", "i-Construction", "TEC", 360, "更新頻度低め。"),
+    MonitorSeed("i-Construction 2.0（策定：報道発表）", "https://www.mlit.go.jp/report/press/kanbo08_hh_001085.html", "HTML_HASH", "報告書", "i-Construction", "PRESS", 120, "本文PDFへの導線。"),
+    MonitorSeed("i-Construction 2.0（本文PDF）", "https://www.mlit.go.jp/tec/constplan/content/001738240.pdf", "HTTP_META_THEN_HASH", "報告書", "i-Construction", "CONSTPLAN", 720, "方針本文PDF。"),
+    MonitorSeed("ICTの全面的な活用（入口）", "https://www.mlit.go.jp/tec/constplan/sosei_constplan_tk_000031.html", "HTML_HASH", "参考資料", "ICT施工", "CONSTPLAN", 60, "メニュー集約ページ。"),
+    MonitorSeed("ICTの全面的な活用：要領関係等（一覧）", "https://www.mlit.go.jp/tec/constplan/sosei_constplan_tk_000051.html", "HTML_HASH", "要領", "ICT施工", "CONSTPLAN", 60, "実施/積算要領の中核。"),
+    MonitorSeed("国土交通省インフラ分野のDX（総合ハブ）", "https://www.mlit.go.jp/tec/tec_tk_000073.html", "HTML_HASH", "参考資料", "インフラDX", "TEC", 60, "DX関連総合ハブ。"),
+    MonitorSeed("オープンデータ取組方針（本文PDF）", "https://www.mlit.go.jp/tec/content/001884707.pdf", "HTTP_META_THEN_HASH", "方針", "オープンデータ", "TEC", 720, "方針PDF。"),
+    MonitorSeed("国土交通データプラットフォーム（技術調査ハブ）", "https://www.mlit.go.jp/tec/tec_tk_000066.html", "HTML_HASH", "参考資料", "データプラットフォーム", "TEC", 120, "DPFリンク集。"),
+    MonitorSeed("国土交通DPF：データ連携標準仕様（案）Ver1.1（PDF）", "https://www.mlit.go.jp/tec/content/001901915.pdf", "HTTP_META_THEN_HASH", "基準", "データプラットフォーム", "TEC", 720, "標準仕様PDF。"),
+    MonitorSeed("国土交通DPF：ドメイン変更（2026/01/20）報道発表", "https://www.mlit.go.jp/report/press/kanbo08_hh_001287.html", "HTML_HASH", "事務連絡", "データプラットフォーム", "PRESS", 360, "URL変更告知。"),
+    MonitorSeed("xROAD（道路データプラットフォーム）トップ", "https://www.xroad.mlit.go.jp/", "HTML_HASH", "参考資料", "道路DX", "ROAD", 120, "導線集約ページ。"),
+    MonitorSeed("xROAD：データベース一覧", "https://www.xroad.mlit.go.jp/database/", "HTML_HASH", "参考資料", "道路DX", "ROAD", 120, "DB追加/差替監視。"),
+    MonitorSeed("xROAD：道路データビューア", "https://view.xroad.mlit.go.jp/", "HTTP_META_ONLY", "ツール", "道路DX", "ROAD", 720, "動的ページ想定、疎監視。"),
+    MonitorSeed("PLATEAU（トップ）", "https://www.mlit.go.jp/plateau/", "HTML_HASH", "参考資料", "オープンデータ", "URBAN", 120, "PLATEAU入口。"),
+    MonitorSeed("PLATEAU：News", "https://www.mlit.go.jp/plateau/news/", "HTML_HASH", "参考資料", "オープンデータ", "URBAN", 60, "ニュース追加監視。"),
+    MonitorSeed("PLATEAU：Libraries（Recent Updatesあり）", "https://www.mlit.go.jp/plateau/libraries/", "HTML_HASH", "参考資料", "オープンデータ", "URBAN", 120, "技術資料の更新監視。"),
+    MonitorSeed("PLATEAU：Open Data（Last update表示）", "https://www.mlit.go.jp/plateau/open-data/", "HTML_HASH", "参考資料", "オープンデータ", "URBAN", 120, "Last update表示あり。"),
+    MonitorSeed("港湾：港湾におけるi-Construction（要領・委員会）", "https://www.mlit.go.jp/kowan/kowan_fr5_000061.html", "HTML_HASH", "実施方針", "港湾DX", "PORT", 120, "港湾ICT/BIM/CIMハブ。"),
+    MonitorSeed("サイバーポート（港湾インフラ分野）ポータル", "https://www.cyber-port.mlit.go.jp/infra/", "HTML_HASH", "ツール", "港湾DX", "PORT", 360, "ポータル入口監視。"),
+    MonitorSeed("港湾：サイバーポート（説明ページ）", "https://www.mlit.go.jp/kowan/kowan_00002.html", "HTML_HASH", "参考資料", "港湾DX", "PORT", 720, "更新低頻度。"),
+    MonitorSeed("関東：インフラDXポータル（入口）", "https://www.ktr.mlit.go.jp/portal-dx/index.html", "HTML_HASH", "参考資料", "インフラDX", "KTR", 120, "局内標準リンク入口。"),
+    MonitorSeed("関東：様式・基準（BIM/CIM・ICT・積算リンク集）", "https://www.ktr.mlit.go.jp/portal-dx/youshiki/index.html", "HTML_HASH", "参考資料", "BIM/CIM", "KTR", 120, "実務導線リンク集。"),
+    MonitorSeed("中部：建設ICT総合サイト（入口）", "https://www.cbr.mlit.go.jp/kensetsu-ict/", "HTML_HASH", "参考資料", "ICT施工", "CBR", 120, "中部局ICT入口。"),
+    MonitorSeed("中部：基準・要領類（局サイト）", "https://www.cbr.mlit.go.jp/kensetsu-ict/ict-kijun.html", "HTML_HASH", "参考資料", "ICT施工", "CBR", 120, "局視点の基準整理。"),
+    MonitorSeed("東北：インフラDX（新着あり）", "https://www.thr.mlit.go.jp/Bumon/B00097/k00915/dxhp/dxhp.html", "HTML_HASH", "参考資料", "インフラDX", "THR", 120, "時系列新着あり。"),
+    MonitorSeed("中部：インフラDX", "https://www.cbr.mlit.go.jp/kikaku/dx/infrastructure_dx.html", "HTML_HASH", "参考資料", "インフラDX", "CBR", 120, "中部局DX入口。"),
+    MonitorSeed("中国：インフラDX（局ハブ）", "https://www.cgr.mlit.go.jp/infradx/index.html", "HTML_HASH", "参考資料", "インフラDX", "CGR", 120, "推進計画/会議リンク集。"),
+    MonitorSeed("四国：インフラDX推進（局）", "https://www.skr.mlit.go.jp/kikaku/infraDX/", "HTML_HASH", "参考資料", "インフラDX", "SKR", 120, "四国局DX導線。"),
+    MonitorSeed("九州：九州インフラDX推進室（入口）", "https://www.qsr.mlit.go.jp/infradx/index.html", "HTML_HASH", "参考資料", "インフラDX", "QSR", 120, "九州局DX入口。"),
+]
+
+
+def utcnow_iso() -> str:
+    return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+
+def connect(db_path: str) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_db(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS monitors (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          display_name TEXT NOT NULL,
+          url TEXT NOT NULL UNIQUE,
+          watch_type TEXT NOT NULL,
+          document_type TEXT,
+          category TEXT,
+          bureau_code TEXT,
+          interval_min INTEGER NOT NULL DEFAULT 60,
+          enabled INTEGER NOT NULL DEFAULT 1,
+          note TEXT,
+          created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+        );
+
+        CREATE TABLE IF NOT EXISTS monitor_state (
+          monitor_id INTEGER PRIMARY KEY,
+          last_checked_at TEXT,
+          last_http_status INTEGER,
+          last_error TEXT,
+          fingerprint TEXT,
+          etag TEXT,
+          last_modified TEXT,
+          content_length INTEGER,
+          stable_count INTEGER NOT NULL DEFAULT 0,
+          changed_count INTEGER NOT NULL DEFAULT 0,
+          FOREIGN KEY (monitor_id) REFERENCES monitors(id) ON DELETE CASCADE
+        );
+
+        CREATE TABLE IF NOT EXISTS change_events (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          monitor_id INTEGER NOT NULL,
+          detected_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+          change_type TEXT NOT NULL,
+          prev_fingerprint TEXT,
+          new_fingerprint TEXT,
+          prev_etag TEXT,
+          new_etag TEXT,
+          prev_last_modified TEXT,
+          new_last_modified TEXT,
+          http_status INTEGER,
+          summary TEXT,
+          snapshot_path TEXT,
+          notified INTEGER NOT NULL DEFAULT 0,
+          FOREIGN KEY (monitor_id) REFERENCES monitors(id) ON DELETE CASCADE
+        );
+
+        CREATE INDEX IF NOT EXISTS idx_change_events_monitor_detected
+          ON change_events(monitor_id, detected_at DESC);
+        """
+    )
+    conn.commit()
+
+
+def seed_defaults(conn: sqlite3.Connection) -> int:
+    inserted = 0
+    for s in SEEDS:
+        before = conn.total_changes
+        conn.execute(
+            """
+            INSERT INTO monitors (display_name, url, watch_type, document_type, category, bureau_code, interval_min, enabled, note)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 1, ?)
+            ON CONFLICT(url) DO UPDATE SET
+              display_name=excluded.display_name,
+              watch_type=excluded.watch_type,
+              document_type=excluded.document_type,
+              category=excluded.category,
+              bureau_code=excluded.bureau_code,
+              interval_min=excluded.interval_min,
+              note=excluded.note
+            """,
+            (s.display_name, s.url, s.watch_type, s.document_type, s.category, s.bureau_code, s.interval_min, s.note),
+        )
+        if conn.total_changes > before:
+            inserted += 1
+
+    conn.execute(
+        """
+        INSERT INTO monitor_state (monitor_id, last_checked_at)
+        SELECT m.id, NULL
+        FROM monitors m
+        LEFT JOIN monitor_state s ON s.monitor_id = m.id
+        WHERE s.monitor_id IS NULL
+        """
+    )
+    conn.commit()
+    return inserted
+
+
+def normalize_html_for_hash(html: str) -> str:
+    # Remove script/style/comment blocks, then trim whitespace.
+    html = re.sub(r"<!--.*?-->", " ", html, flags=re.S)
+    html = re.sub(r"<script\b[^>]*>.*?</script>", " ", html, flags=re.S | re.I)
+    html = re.sub(r"<style\b[^>]*>.*?</style>", " ", html, flags=re.S | re.I)
+    html = re.sub(r"\s+", " ", html)
+    return html.strip()
+
+
+def sha256_text(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8", errors="ignore")).hexdigest()
+
+
+def http_head(url: str) -> tuple[Optional[str], Optional[str], Optional[int]]:
+    req = urllib.request.Request(url, method="HEAD", headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+            headers = resp.headers
+            return headers.get("ETag"), headers.get("Last-Modified"), getattr(resp, "status", None)
+    except Exception:
+        return None, None, None
+
+
+def http_get(url: str) -> tuple[int, bytes, Optional[str], Optional[str], dict[str, str]]:
+    req = urllib.request.Request(url, method="GET", headers={"User-Agent": USER_AGENT})
+    with urllib.request.urlopen(req, timeout=TIMEOUT_SEC) as resp:
+        body = resp.read()
+        headers = {k: v for k, v in resp.headers.items()}
+        return getattr(resp, "status", 200), body, resp.headers.get_content_type(), resp.headers.get_content_charset(), headers
+
+
+def fingerprint_for_monitor(url: str, watch_type: str) -> dict[str, Optional[str] | int]:
+    etag, last_modified, head_status = (None, None, None)
+    if watch_type in ("HTTP_META_ONLY", "HTTP_META_THEN_HASH"):
+        etag, last_modified, head_status = http_head(url)
+
+    if watch_type == "HTTP_META_ONLY":
+        fp_src = f"etag={etag}|lm={last_modified}"
+        return {
+            "fingerprint": sha256_text(fp_src),
+            "etag": etag,
+            "last_modified": last_modified,
+            "http_status": head_status or 0,
+            "content_length": None,
+            "summary": "meta-only check",
+        }
+
+    status, raw, content_type, charset, headers = http_get(url)
+    etag = headers.get("ETag") or etag
+    last_modified = headers.get("Last-Modified") or last_modified
+
+    if content_type and "html" in content_type:
+        text = raw.decode(charset or "utf-8", errors="ignore")
+        norm = normalize_html_for_hash(text)
+        fp = sha256_text(norm)
+        summary = f"html bytes={len(raw)}"
+    else:
+        fp = hashlib.sha256(raw).hexdigest()
+        summary = f"binary bytes={len(raw)}"
+
+    if watch_type == "HTTP_META_THEN_HASH":
+        fp = sha256_text(f"fp={fp}|etag={etag}|lm={last_modified}")
+
+    return {
+        "fingerprint": fp,
+        "etag": etag,
+        "last_modified": last_modified,
+        "http_status": status,
+        "content_length": len(raw),
+        "summary": summary,
+    }
+
+
+def iter_targets(conn: sqlite3.Connection, limit: Optional[int] = None) -> Iterable[sqlite3.Row]:
+    sql = """
+    SELECT m.*, s.fingerprint AS prev_fingerprint, s.etag AS prev_etag, s.last_modified AS prev_last_modified
+    FROM monitors m
+    LEFT JOIN monitor_state s ON s.monitor_id = m.id
+    WHERE m.enabled = 1
+    ORDER BY m.id
+    """
+    if limit:
+        sql += f" LIMIT {int(limit)}"
+    return conn.execute(sql)
+
+
+def process_one(conn: sqlite3.Connection, row: sqlite3.Row) -> str:
+    monitor_id = row["id"]
+    try:
+        res = fingerprint_for_monitor(row["url"], row["watch_type"])
+        changed = (row["prev_fingerprint"] is not None) and (row["prev_fingerprint"] != res["fingerprint"])
+        change_type = "content_changed" if changed else "stable"
+
+        if changed:
+            conn.execute(
+                """
+                INSERT INTO change_events (
+                    monitor_id, detected_at, change_type,
+                    prev_fingerprint, new_fingerprint,
+                    prev_etag, new_etag,
+                    prev_last_modified, new_last_modified,
+                    http_status, summary, notified
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 0)
+                """,
+                (
+                    monitor_id,
+                    utcnow_iso(),
+                    change_type,
+                    row["prev_fingerprint"],
+                    res["fingerprint"],
+                    row["prev_etag"],
+                    res["etag"],
+                    row["prev_last_modified"],
+                    res["last_modified"],
+                    res["http_status"],
+                    res["summary"],
+                ),
+            )
+
+        conn.execute(
+            """
+            INSERT INTO monitor_state (
+                monitor_id, last_checked_at, last_http_status, last_error,
+                fingerprint, etag, last_modified, content_length, stable_count, changed_count
+            ) VALUES (?, ?, ?, NULL, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(monitor_id) DO UPDATE SET
+                last_checked_at=excluded.last_checked_at,
+                last_http_status=excluded.last_http_status,
+                last_error=NULL,
+                fingerprint=excluded.fingerprint,
+                etag=excluded.etag,
+                last_modified=excluded.last_modified,
+                content_length=excluded.content_length,
+                stable_count=CASE WHEN excluded.fingerprint != monitor_state.fingerprint THEN 0 ELSE monitor_state.stable_count + 1 END,
+                changed_count=CASE WHEN excluded.fingerprint != monitor_state.fingerprint THEN monitor_state.changed_count + 1 ELSE monitor_state.changed_count END
+            """,
+            (
+                monitor_id,
+                utcnow_iso(),
+                res["http_status"],
+                res["fingerprint"],
+                res["etag"],
+                res["last_modified"],
+                res["content_length"],
+                1,
+                0,
+            ),
+        )
+        conn.commit()
+        return f"OK   #{monitor_id} {row['display_name']}"
+    except urllib.error.URLError as e:
+        msg = f"{type(e).__name__}: {e.reason}" if getattr(e, "reason", None) else str(e)
+    except Exception as e:  # noqa: BLE001
+        msg = f"{type(e).__name__}: {e}"
+
+    conn.execute(
+        """
+        INSERT INTO change_events (monitor_id, detected_at, change_type, http_status, summary, notified)
+        VALUES (?, ?, 'fetch_error', NULL, ?, 0)
+        """,
+        (monitor_id, utcnow_iso(), msg[:400]),
+    )
+    conn.execute(
+        """
+        INSERT INTO monitor_state (monitor_id, last_checked_at, last_http_status, last_error)
+        VALUES (?, ?, NULL, ?)
+        ON CONFLICT(monitor_id) DO UPDATE SET
+          last_checked_at=excluded.last_checked_at,
+          last_error=excluded.last_error
+        """,
+        (monitor_id, utcnow_iso(), msg[:400]),
+    )
+    conn.commit()
+    return f"ERR  #{monitor_id} {row['display_name']} :: {msg}"
+
+
+def run_once(conn: sqlite3.Connection, limit: Optional[int]) -> None:
+    rows = list(iter_targets(conn, limit=limit))
+    for row in rows:
+        print(process_one(conn, row))
+
+
+def list_monitors(conn: sqlite3.Connection) -> None:
+    rows = conn.execute(
+        """
+        SELECT m.id, m.display_name, m.watch_type, m.interval_min, m.url,
+               s.last_checked_at, s.last_error
+        FROM monitors m
+        LEFT JOIN monitor_state s ON s.monitor_id = m.id
+        ORDER BY m.id
+        """
+    ).fetchall()
+    for r in rows:
+        print(json.dumps(dict(r), ensure_ascii=False))
+
+
+def run_daemon(conn: sqlite3.Connection, poll_sec: int, limit: Optional[int]) -> None:
+    print(f"daemon started: poll={poll_sec}s db={DB_PATH}")
+    while True:
+        run_once(conn, limit=limit)
+        time.sleep(poll_sec)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Simple Web page watcher")
+    parser.add_argument("--db", default=DB_PATH, help="sqlite db path")
+
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("init-db", help="create tables")
+    sub.add_parser("seed-defaults", help="upsert built-in monitor URLs")
+    sub.add_parser("list-monitors", help="show monitors")
+
+    run_once_p = sub.add_parser("run-once", help="execute checks once")
+    run_once_p.add_argument("--limit", type=int, default=None)
+
+    daemon_p = sub.add_parser("run-daemon", help="run repeatedly")
+    daemon_p.add_argument("--poll-sec", type=int, default=300)
+    daemon_p.add_argument("--limit", type=int, default=None)
+
+    args = parser.parse_args()
+    conn = connect(args.db)
+
+    if args.cmd == "init-db":
+        init_db(conn)
+        print("initialized")
+    elif args.cmd == "seed-defaults":
+        init_db(conn)
+        count = seed_defaults(conn)
+        print(f"seeded/upserted: {count}")
+    elif args.cmd == "list-monitors":
+        list_monitors(conn)
+    elif args.cmd == "run-once":
+        run_once(conn, limit=args.limit)
+    elif args.cmd == "run-daemon":
+        run_daemon(conn, poll_sec=args.poll_sec, limit=args.limit)
+
+
+if __name__ == "__main__":
+    main()

--- a/run_web.py
+++ b/run_web.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+"""One-click launcher for the monitoring website."""
+from web_app import main
+
+if __name__ == "__main__":
+    main()

--- a/start_web.bat
+++ b/start_web.bat
@@ -1,0 +1,4 @@
+@echo off
+cd /d %~dp0
+python run_web.py
+pause

--- a/start_web.sh
+++ b/start_web.sh
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+cd "$(dirname "$0")"
+python3 run_web.py

--- a/web_app.py
+++ b/web_app.py
@@ -1,0 +1,287 @@
+#!/usr/bin/env python3
+"""Simple web UI for the monitor_app SQLite watcher."""
+from __future__ import annotations
+
+import argparse
+import html
+import sqlite3
+from http import HTTPStatus
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from urllib.parse import parse_qs, urlparse
+
+import monitor_app
+
+
+DB_PATH = monitor_app.DB_PATH
+
+
+CSS = """
+body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; margin: 24px; }
+h1 { margin-bottom: 8px; }
+small { color: #555; }
+table { border-collapse: collapse; width: 100%; margin: 12px 0 24px; }
+th, td { border: 1px solid #ddd; padding: 8px; vertical-align: top; font-size: 14px; }
+th { background: #f7f7f7; text-align: left; }
+input, select, button { padding: 8px; margin: 4px 0; }
+form.inline { display: inline-block; margin-right: 12px; }
+section.card { border: 1px solid #ddd; border-radius: 8px; padding: 16px; margin-bottom: 20px; }
+.flash { padding: 10px; background: #eef7ff; border: 1px solid #b6ddff; border-radius: 6px; margin-bottom: 16px; }
+"""
+
+
+def get_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(DB_PATH)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def page(title: str, body: str) -> bytes:
+    doc = f"""<!doctype html>
+<html lang=\"ja\">
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>{html.escape(title)}</title>
+  <style>{CSS}</style>
+</head>
+<body>
+  {body}
+</body>
+</html>"""
+    return doc.encode("utf-8")
+
+
+def fetch_monitors() -> list[sqlite3.Row]:
+    with get_conn() as conn:
+        return conn.execute(
+            """
+            SELECT m.id, m.display_name, m.watch_type, m.document_type, m.category,
+                   m.bureau_code, m.interval_min, m.url, s.last_checked_at, s.last_error
+            FROM monitors m
+            LEFT JOIN monitor_state s ON s.monitor_id = m.id
+            WHERE m.enabled = 1
+            ORDER BY m.id
+            """
+        ).fetchall()
+
+
+def fetch_events(limit: int = 100) -> list[sqlite3.Row]:
+    with get_conn() as conn:
+        return conn.execute(
+            """
+            SELECT e.detected_at, e.change_type, e.summary, m.display_name, m.url
+            FROM change_events e
+            JOIN monitors m ON m.id = e.monitor_id
+            ORDER BY e.id DESC
+            LIMIT ?
+            """,
+            (limit,),
+        ).fetchall()
+
+
+def add_monitor(form: dict[str, list[str]]) -> None:
+    display_name = (form.get("display_name", [""])[0]).strip()
+    url = (form.get("url", [""])[0]).strip()
+    watch_type = (form.get("watch_type", ["HTML_HASH"])[0]).strip()
+    document_type = (form.get("document_type", [""])[0]).strip()
+    category = (form.get("category", [""])[0]).strip()
+    bureau_code = (form.get("bureau_code", [""])[0]).strip()
+    interval_min_raw = (form.get("interval_min", ["60"])[0]).strip()
+
+    if not display_name or not url:
+        raise ValueError("表示名とURLは必須です。")
+
+    try:
+        interval_min = max(5, int(interval_min_raw))
+    except ValueError as exc:
+        raise ValueError("監視間隔は数字で入力してください。") from exc
+
+    with get_conn() as conn:
+        conn.execute(
+            """
+            INSERT INTO monitors (display_name, url, watch_type, document_type, category, bureau_code, interval_min, enabled, note)
+            VALUES (?, ?, ?, ?, ?, ?, ?, 1, 'Web UIで追加')
+            ON CONFLICT(url) DO UPDATE SET
+              display_name=excluded.display_name,
+              watch_type=excluded.watch_type,
+              document_type=excluded.document_type,
+              category=excluded.category,
+              bureau_code=excluded.bureau_code,
+              interval_min=excluded.interval_min,
+              enabled=1
+            """,
+            (display_name, url, watch_type, document_type, category, bureau_code, interval_min),
+        )
+        conn.execute(
+            """
+            INSERT INTO monitor_state (monitor_id, last_checked_at)
+            SELECT m.id, NULL
+            FROM monitors m
+            LEFT JOIN monitor_state s ON s.monitor_id = m.id
+            WHERE s.monitor_id IS NULL
+            """
+        )
+        conn.commit()
+
+
+def render_home(flash_message: str = "") -> bytes:
+    monitors = fetch_monitors()
+    events = fetch_events(limit=20)
+
+    monitor_rows = "".join(
+        f"<tr>"
+        f"<td>{m['id']}</td>"
+        f"<td>{html.escape(m['display_name'])}</td>"
+        f"<td>{html.escape(m['watch_type'])}</td>"
+        f"<td>{html.escape(m['category'] or '')}</td>"
+        f"<td>{m['interval_min']}分</td>"
+        f"<td><a href=\"{html.escape(m['url'])}\" target=\"_blank\">{html.escape(m['url'])}</a></td>"
+        f"<td>{html.escape(m['last_checked_at'] or '-')}</td>"
+        f"<td>{html.escape(m['last_error'] or '-')}</td>"
+        f"</tr>"
+        for m in monitors
+    )
+
+    event_rows = "".join(
+        f"<tr>"
+        f"<td>{html.escape(e['detected_at'] or '-')}</td>"
+        f"<td>{html.escape(e['change_type'] or '-')}</td>"
+        f"<td>{html.escape(e['display_name'] or '-')}</td>"
+        f"<td>{html.escape(e['summary'] or '-')}</td>"
+        f"</tr>"
+        for e in events
+    )
+
+    flash = f"<div class='flash'>{html.escape(flash_message)}</div>" if flash_message else ""
+
+    body = f"""
+    <h1>監視Webサイト</h1>
+    <small>ブラウザからURL登録・監視実行・履歴確認ができます。</small>
+    {flash}
+
+    <section class=\"card\">
+      <h2>操作</h2>
+      <form class=\"inline\" method=\"post\" action=\"/seed\">
+        <button type=\"submit\">45件の初期URLを投入</button>
+      </form>
+      <form class=\"inline\" method=\"post\" action=\"/run\">
+        <input type=\"number\" name=\"limit\" value=\"5\" min=\"1\" style=\"width:80px\"> 件だけ監視
+        <button type=\"submit\">監視を実行</button>
+      </form>
+    </section>
+
+    <section class=\"card\">
+      <h2>URLを追加</h2>
+      <form method=\"post\" action=\"/add\">
+        <div><input name=\"display_name\" placeholder=\"表示名\" style=\"width:320px\" required></div>
+        <div><input name=\"url\" type=\"url\" placeholder=\"https://...\" style=\"width:520px\" required></div>
+        <div>
+          <select name=\"watch_type\">
+            <option value=\"HTML_HASH\">HTML_HASH</option>
+            <option value=\"HTTP_META_THEN_HASH\">HTTP_META_THEN_HASH</option>
+            <option value=\"HTTP_META_ONLY\">HTTP_META_ONLY</option>
+          </select>
+          <input name=\"document_type\" placeholder=\"DocumentType\" style=\"width:140px\">
+          <input name=\"category\" placeholder=\"Category\" style=\"width:140px\">
+          <input name=\"bureau_code\" placeholder=\"部局コード\" style=\"width:120px\">
+          <input name=\"interval_min\" type=\"number\" min=\"5\" value=\"60\" style=\"width:90px\"> 分
+        </div>
+        <button type=\"submit\">追加 / 更新</button>
+      </form>
+    </section>
+
+    <section class=\"card\">
+      <h2>監視対象 ({len(monitors)}件)</h2>
+      <table>
+        <thead><tr><th>ID</th><th>表示名</th><th>方式</th><th>カテゴリ</th><th>間隔</th><th>URL</th><th>最終確認</th><th>最終エラー</th></tr></thead>
+        <tbody>{monitor_rows}</tbody>
+      </table>
+    </section>
+
+    <section class=\"card\">
+      <h2>最新イベント (20件)</h2>
+      <table>
+        <thead><tr><th>時刻</th><th>種別</th><th>対象</th><th>概要</th></tr></thead>
+        <tbody>{event_rows}</tbody>
+      </table>
+    </section>
+    """
+    return page("監視Webサイト", body)
+
+
+class Handler(BaseHTTPRequestHandler):
+    def _send_html(self, content: bytes, status: int = HTTPStatus.OK) -> None:
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(content)))
+        self.end_headers()
+        self.wfile.write(content)
+
+    def _redirect(self, to: str) -> None:
+        self.send_response(HTTPStatus.SEE_OTHER)
+        self.send_header("Location", to)
+        self.end_headers()
+
+    def _read_form(self) -> dict[str, list[str]]:
+        length = int(self.headers.get("Content-Length", "0"))
+        data = self.rfile.read(length).decode("utf-8", errors="ignore")
+        return parse_qs(data)
+
+    def do_GET(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        if path == "/":
+            self._send_html(render_home())
+            return
+        self._send_html(page("Not Found", "<h1>404 Not Found</h1>"), status=HTTPStatus.NOT_FOUND)
+
+    def do_POST(self) -> None:  # noqa: N802
+        path = urlparse(self.path).path
+        form = self._read_form()
+        try:
+            if path == "/seed":
+                with get_conn() as conn:
+                    monitor_app.init_db(conn)
+                    count = monitor_app.seed_defaults(conn)
+                self._send_html(render_home(f"初期データを投入しました（変更件数: {count}）。"))
+                return
+            if path == "/run":
+                limit_raw = (form.get("limit", ["5"])[0]).strip()
+                limit = max(1, int(limit_raw))
+                with get_conn() as conn:
+                    for row in list(monitor_app.iter_targets(conn, limit=limit)):
+                        monitor_app.process_one(conn, row)
+                self._send_html(render_home(f"監視を実行しました（対象: {limit}件）。"))
+                return
+            if path == "/add":
+                add_monitor(form)
+                self._send_html(render_home("URLを追加/更新しました。"))
+                return
+            self._redirect("/")
+        except Exception as exc:  # noqa: BLE001
+            self._send_html(render_home(f"エラー: {exc}"), status=HTTPStatus.BAD_REQUEST)
+
+
+def main() -> None:
+    global DB_PATH
+    parser = argparse.ArgumentParser(description="Web UI for monitor_app")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8000)
+    parser.add_argument("--db", default=DB_PATH)
+    args = parser.parse_args()
+    DB_PATH = args.db
+
+    with get_conn() as conn:
+        monitor_app.init_db(conn)
+
+    server = ThreadingHTTPServer((args.host, args.port), Handler)
+    print(f"Web UI started: http://{args.host}:{args.port}")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+
+
+if __name__ == "__main__":
+    main()

--- a/web_app.py
+++ b/web_app.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import html
 import sqlite3
+import webbrowser
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from urllib.parse import parse_qs, urlparse
@@ -77,6 +78,14 @@ def fetch_events(limit: int = 100) -> list[sqlite3.Row]:
             """,
             (limit,),
         ).fetchall()
+
+
+def ensure_seeded_if_empty() -> int:
+    with get_conn() as conn:
+        count = conn.execute("SELECT COUNT(*) FROM monitors").fetchone()[0]
+        if count == 0:
+            return monitor_app.seed_defaults(conn)
+        return 0
 
 
 def add_monitor(form: dict[str, list[str]]) -> None:
@@ -267,14 +276,24 @@ def main() -> None:
     parser.add_argument("--host", default="127.0.0.1")
     parser.add_argument("--port", type=int, default=8000)
     parser.add_argument("--db", default=DB_PATH)
+    parser.add_argument("--no-open-browser", action="store_true", help="do not auto-open browser")
     args = parser.parse_args()
     DB_PATH = args.db
 
     with get_conn() as conn:
         monitor_app.init_db(conn)
+    seeded = ensure_seeded_if_empty()
 
     server = ThreadingHTTPServer((args.host, args.port), Handler)
-    print(f"Web UI started: http://{args.host}:{args.port}")
+    url = f"http://{args.host}:{args.port}"
+    print(f"Web UI started: {url}")
+    if seeded:
+        print(f"Initial monitors seeded: {seeded}")
+    if not args.no_open_browser:
+        try:
+            webbrowser.open(url, new=2)
+        except Exception:
+            pass
     try:
         server.serve_forever()
     except KeyboardInterrupt:


### PR DESCRIPTION
### Motivation

- Provide a minimal, standalone web-page monitoring tool for MLIT-related pages using only the standard library and SQLite. 
- Support lightweight change detection strategies (HTML hashing and HTTP metadata) for different document types and frequencies. 
- Include a curated seed list of target URLs to bootstrap monitoring for common MLIT hubs and resources.

### Description

- Add `monitor_app.py`, a CLI app that creates a SQLite schema (`monitors`, `monitor_state`, `change_events`) and implements `init-db`, `seed-defaults`, `list-monitors`, `run-once`, and `run-daemon` commands. 
- Implement content fingerprinting with `normalize_html_for_hash`, `sha256_text`, `http_head`, and `http_get`, and support `HTML_HASH`, `HTTP_META_THEN_HASH`, and `HTTP_META_ONLY` watch types. 
- Provide upsert logic for seeded monitors via `seed_defaults`, state change detection with `change_events`, and atomic state updates using `ON CONFLICT` clauses. 
- Add `README.md` with setup and usage examples and a `.gitignore` excluding `__pycache__/`, `*.pyc`, and `watcher.db`.

### Testing

- No automated tests were added or run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69db7e2d3740832ca8720206ef2323af)